### PR TITLE
Update node & MC

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14-slim
+FROM node:16-slim
 RUN apt-get update && apt-get -y install libcap2-bin \
   && rm -rf /var/lib/apt/lists/* \
   && setcap cap_net_bind_service=+ep '/usr/local/bin/node'
@@ -6,6 +6,6 @@ RUN mkdir -p /home/node/meshcentral/node_modules && chown -R node:node /home/nod
 USER node
 WORKDIR /home/node/meshcentral
 COPY package*.json ./
-RUN npm install meshcentral@0.9.68
+RUN npm install meshcentral@0.9.77
 
 ENTRYPOINT node ./node_modules/meshcentral/meshcentral.js


### PR DESCRIPTION
Node LTS since October 2021 is v16 and that's what MC uses. You never know when v14 might get incompatible.
MC latest version 0.9.77